### PR TITLE
Consistent spelling of "Signalling"

### DIFF
--- a/Samples/ChatterBox-Sample/ChatterBox.Background/Signaling/SocketConnection.cs
+++ b/Samples/ChatterBox-Sample/ChatterBox.Background/Signaling/SocketConnection.cs
@@ -73,7 +73,7 @@ namespace ChatterBox.Background.Signaling
                     return true;
                 }
 
-                // Disconnect our connection with the Signalling Server.
+                // Disconnect our connection with the Signaling Server.
                 // The server will automatically recognize that the client
                 // is not registered anymore, once it missed the next two heartbeats.
                 await _signalingSocketChannel.DisconnectSignalingServerAsync();

--- a/Samples/ChatterBox-Sample/ChatterBox.Background/SignalingSocketChannel.cs
+++ b/Samples/ChatterBox-Sample/ChatterBox.Background/SignalingSocketChannel.cs
@@ -54,7 +54,7 @@ namespace ChatterBox.Background
                 }
                 catch (Exception exception)
                 {
-                    Debug.WriteLine("Failed to connect to signalling server: ex: " + exception.Message);
+                    Debug.WriteLine("Failed to connect to signaling server: ex: " + exception.Message);
                     return new ConnectionStatus
                     {
                         IsConnected = false

--- a/Samples/DataChannelOrtc/DataChannelOrtc/DataChannelOrtc.csproj
+++ b/Samples/DataChannelOrtc/DataChannelOrtc/DataChannelOrtc.csproj
@@ -98,11 +98,11 @@
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Signalling\Peer.cs" />
+    <Compile Include="Signaling\Peer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Signalling\Signaler.cs" />
-    <Compile Include="Signalling\TcpSignaler.cs" />
-    <Compile Include="Signalling\Util.cs" />
+    <Compile Include="Signaling\Signaler.cs" />
+    <Compile Include="Signaling\TcpSignaler.cs" />
+    <Compile Include="Signaling\Util.cs" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">

--- a/Samples/DataChannelOrtc/DataChannelOrtc/MainPage.xaml.cs
+++ b/Samples/DataChannelOrtc/DataChannelOrtc/MainPage.xaml.cs
@@ -19,7 +19,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
-using DataChannelOrtc.Signalling;
+using DataChannelOrtc.Signaling;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 

--- a/Samples/DataChannelOrtc/DataChannelOrtc/Signaling/Peer.cs
+++ b/Samples/DataChannelOrtc/DataChannelOrtc/Signaling/Peer.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DataChannelOrtc.Signalling
+namespace DataChannelOrtc.Signaling
 {
     public class Peer
     {

--- a/Samples/DataChannelOrtc/DataChannelOrtc/Signaling/Signaler.cs
+++ b/Samples/DataChannelOrtc/DataChannelOrtc/Signaling/Signaler.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DataChannelOrtc.Signalling
+namespace DataChannelOrtc.Signaling
 {
     abstract class Signaler
     {

--- a/Samples/DataChannelOrtc/DataChannelOrtc/Signaling/Util.cs
+++ b/Samples/DataChannelOrtc/DataChannelOrtc/Signaling/Util.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Windows.Networking.Sockets;
 using Windows.Storage.Streams;
 
-namespace DataChannelOrtc.Signalling
+namespace DataChannelOrtc.Signaling
 {
     /// <summary>
     /// The connection state.

--- a/Samples/PeerCC-Sample/PeerConnectionClient.WebRtc.csproj
+++ b/Samples/PeerCC-Sample/PeerConnectionClient.WebRtc.csproj
@@ -106,8 +106,8 @@
     <Compile Include="Model\Peer.cs" />
     <Compile Include="MVVM\BindableBase.cs" />
     <Compile Include="MVVM\DispatcherBindableBase.cs" />
-    <Compile Include="Signalling\Conductor.cs" />
-    <Compile Include="Signalling\Signalling.cs" />
+    <Compile Include="Signaling\Conductor.cs" />
+    <Compile Include="Signaling\Signaling.cs" />
     <Compile Include="Utilities\ActionCommand.cs" />
     <Compile Include="Utilities\AppPerf.cs" />
     <Compile Include="Utilities\BoolToVisConverter.cs" />

--- a/Samples/PeerCC-Sample/Signaling/Conductor.cs
+++ b/Samples/PeerCC-Sample/Signaling/Conductor.cs
@@ -36,7 +36,7 @@ using Org.WebRtc;
 using PeerConnectionClient.Utilities;
 #endif
 
-namespace PeerConnectionClient.Signalling
+namespace PeerConnectionClient.Signaling
 {
     /// <summary>
     /// A singleton conductor for WebRTC session.
@@ -69,13 +69,13 @@ namespace PeerConnectionClient.Signalling
             }
         }
 
-        private readonly Signaller _signaller;
+        private readonly Signaler _signaler;
 
         /// <summary>
-        /// The signaller property.
+        /// The signaler property.
         /// Helps to pass WebRTC session signals between client and server.
         /// </summary>
-        public Signaller Signaller => _signaller;
+        public Signaler Signaler => _signaler;
         
         /// <summary>
         /// Video codec used in WebRTC session.
@@ -448,25 +448,25 @@ namespace PeerConnectionClient.Signalling
 //#else
             //_signalingMode = RTCPeerConnectionSignalingMode.Sdp;
 #endif
-            _signaller = new Signaller();
+            _signaler = new Signaler();
             _media = Media.CreateMedia();
 
-            Signaller.OnDisconnected += Signaller_OnDisconnected;
-            Signaller.OnMessageFromPeer += Signaller_OnMessageFromPeer;
-            Signaller.OnPeerConnected += Signaller_OnPeerConnected;
-            Signaller.OnPeerHangup += Signaller_OnPeerHangup;
-            Signaller.OnPeerDisconnected += Signaller_OnPeerDisconnected;
-            Signaller.OnServerConnectionFailure += Signaller_OnServerConnectionFailure;
-            Signaller.OnSignedIn += Signaller_OnSignedIn;
+            Signaler.OnDisconnected += Signaler_OnDisconnected;
+            Signaler.OnMessageFromPeer += Signaler_OnMessageFromPeer;
+            Signaler.OnPeerConnected += Signaler_OnPeerConnected;
+            Signaler.OnPeerHangup += Signaler_OnPeerHangup;
+            Signaler.OnPeerDisconnected += Signaler_OnPeerDisconnected;
+            Signaler.OnServerConnectionFailure += Signaler_OnServerConnectionFailure;
+            Signaler.OnSignedIn += Signaler_OnSignedIn;
 
             _iceServers = new List<RTCIceServer>();
         }
 
         /// <summary>
-        /// Handler for Signaller's OnPeerHangup event.
+        /// Handler for Signaler's OnPeerHangup event.
         /// </summary>
         /// <param name="peerId">ID of the peer to hung up the call with.</param>
-        void Signaller_OnPeerHangup(int peerId)
+        void Signaler_OnPeerHangup(int peerId)
         {
             if (peerId != _peerId) return;
 
@@ -475,25 +475,25 @@ namespace PeerConnectionClient.Signalling
         }
 
         /// <summary>
-        /// Handler for Signaller's OnSignedIn event.
+        /// Handler for Signaler's OnSignedIn event.
         /// </summary>
-        private void Signaller_OnSignedIn()
+        private void Signaler_OnSignedIn()
         {
         }
 
         /// <summary>
-        /// Handler for Signaller's OnServerConnectionFailure event.
+        /// Handler for Signaler's OnServerConnectionFailure event.
         /// </summary>
-        private void Signaller_OnServerConnectionFailure()
+        private void Signaler_OnServerConnectionFailure()
         {
             Debug.WriteLine("[Error]: Connection to server failed!");
         }
 
         /// <summary>
-        /// Handler for Signaller's OnPeerDisconnected event.
+        /// Handler for Signaler's OnPeerDisconnected event.
         /// </summary>
         /// <param name="peerId">ID of disconnected peer.</param>
-        private void Signaller_OnPeerDisconnected(int peerId)
+        private void Signaler_OnPeerDisconnected(int peerId)
         {
             // is the same peer or peer_id does not exist (0) in case of 500 Error
             if (peerId != _peerId && peerId != 0) return;
@@ -503,20 +503,20 @@ namespace PeerConnectionClient.Signalling
         }
 
         /// <summary>
-        /// Handler for Signaller's OnPeerConnected event.
+        /// Handler for Signaler's OnPeerConnected event.
         /// </summary>
         /// <param name="id">ID of the connected peer.</param>
         /// <param name="name">Name of the connected peer.</param>
-        private void Signaller_OnPeerConnected(int id, string name)
+        private void Signaler_OnPeerConnected(int id, string name)
         {
         }
 
         /// <summary>
-        /// Handler for Signaller's OnMessageFromPeer event.
+        /// Handler for Signaler's OnMessageFromPeer event.
         /// </summary>
         /// <param name="peerId">ID of the peer.</param>
         /// <param name="message">Message from the peer.</param>
-        private void Signaller_OnMessageFromPeer(int peerId, string message)
+        private void Signaler_OnMessageFromPeer(int peerId, string message)
         {
             Task.Run(async () =>
             {
@@ -567,7 +567,7 @@ namespace PeerConnectionClient.Signalling
                             if (!connectResult)
                             {
                                 Debug.WriteLine("[Error] Conductor: Failed to initialize our PeerConnection instance");
-                                await Signaller.SignOut();
+                                await Signaler.SignOut();
                                 return;
                             }
                             else if (_peerId != peerId)
@@ -695,9 +695,9 @@ namespace PeerConnectionClient.Signalling
         }
 
         /// <summary>
-        /// Handler for Signaller's OnDisconnected event handler.
+        /// Handler for Signaler's OnDisconnected event handler.
         /// </summary>
-        private void Signaller_OnDisconnected()
+        private void Signaler_OnDisconnected()
         {
             ClosePeerConnection();
         }
@@ -709,11 +709,11 @@ namespace PeerConnectionClient.Signalling
         /// <param name="port">The port to connect to.</param>
         public void StartLogin(string server, string port)
         {
-            if (_signaller.IsConnected())
+            if (_signaler.IsConnected())
             {
                 return;
             }
-            _signaller.Connect(server, port, GetLocalPeerName());
+            _signaler.Connect(server, port, GetLocalPeerName());
         }
        
         /// <summary>
@@ -721,9 +721,9 @@ namespace PeerConnectionClient.Signalling
         /// </summary>
         public async Task DisconnectFromServer()
         {
-            if (_signaller.IsConnected())
+            if (_signaler.IsConnected())
             {
-                await _signaller.SignOut();
+                await _signaler.SignOut();
             }
         }
 
@@ -856,7 +856,7 @@ namespace PeerConnectionClient.Signalling
         private void SendMessage(IJsonValue json)
         {
             // Don't await, send it async.
-            var task = _signaller.SendToPeer(_peerId, json);
+            var task = _signaler.SendToPeer(_peerId, json);
         }
 
         /// <summary>
@@ -864,7 +864,7 @@ namespace PeerConnectionClient.Signalling
         /// </summary>
         private async Task SendHangupMessage()
         {
-            await _signaller.SendToPeer(_peerId, "BYE");
+            await _signaler.SendToPeer(_peerId, "BYE");
         }
 
         /// <summary>

--- a/Samples/PeerCC-Sample/ViewModels/MainViewModel.cs
+++ b/Samples/PeerCC-Sample/ViewModels/MainViewModel.cs
@@ -28,7 +28,7 @@ using Windows.UI.Xaml.Controls;
 using Microsoft.HockeyApp;
 using PeerConnectionClient.Model;
 using PeerConnectionClient.MVVM;
-using PeerConnectionClient.Signalling;
+using PeerConnectionClient.Signaling;
 using PeerConnectionClient.Utilities;
 #if ORTCLIB
 using Org.Ortc;
@@ -297,7 +297,7 @@ namespace PeerConnectionClient.ViewModels
             };
 
             // A Peer is connected to the server event handler
-            Conductor.Instance.Signaller.OnPeerConnected += (peerId, peerName) =>
+            Conductor.Instance.Signaler.OnPeerConnected += (peerId, peerName) =>
             {
                 RunOnUiThread(() =>
                 {
@@ -311,7 +311,7 @@ namespace PeerConnectionClient.ViewModels
             };
 
             // A Peer is disconnected from the server event handler
-            Conductor.Instance.Signaller.OnPeerDisconnected += peerId =>
+            Conductor.Instance.Signaler.OnPeerDisconnected += peerId =>
             {
                 RunOnUiThread(() =>
                 {
@@ -322,7 +322,7 @@ namespace PeerConnectionClient.ViewModels
             };
 
             // The user is Signed in to the server event handler
-            Conductor.Instance.Signaller.OnSignedIn += () =>
+            Conductor.Instance.Signaler.OnSignedIn += () =>
             {
                 RunOnUiThread(() =>
                 {
@@ -334,7 +334,7 @@ namespace PeerConnectionClient.ViewModels
             };
 
             // Failed to connect to the server event handler
-            Conductor.Instance.Signaller.OnServerConnectionFailure += () =>
+            Conductor.Instance.Signaler.OnServerConnectionFailure += () =>
             {
                 RunOnUiThread(async () =>
                 {
@@ -345,7 +345,7 @@ namespace PeerConnectionClient.ViewModels
             };
 
             // The current user is disconnected from the server event handler
-            Conductor.Instance.Signaller.OnDisconnected += () =>
+            Conductor.Instance.Signaler.OnDisconnected += () =>
             {
                 RunOnUiThread(() =>
                 {


### PR DESCRIPTION
```Shell
find -type f -exec sed -i -e 's/Signall/Signal/g;s/signall/signal/g' {} \;
mv ./Samples/PeerCC-Sample/Signalling ./Samples/PeerCC-Sample/Signaling
mv ./Samples/PeerCC-Sample/Signaling/Signalling.cs ./Samples/PeerCC-Sample/Signaling/Signaling.cs
mv ./Samples/DataChannelOrtc/DataChannelOrtc/Signalling ./Samples/DataChannelOrtc/DataChannelOrtc/Signaling
```

(using American spelling this time; to be consistent with standard spelling used, e.g.: [`onsignalingstatechange`](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/onsignalingstatechange))