### PR TITLE
Fixed signalling errors

### DIFF
--- a/Samples/DataChannelOrtc/DataChannelOrtc/MainPage.xaml.cs
+++ b/Samples/DataChannelOrtc/DataChannelOrtc/MainPage.xaml.cs
@@ -139,8 +139,8 @@ namespace DataChannelOrtc
         {
             Ortc.Setup();
             Settings.ApplyDefaults();
-            Logger.InstallTelnetLogger(59999, 60, true);
-            Logger.SetLogLevel(Level.Trace);
+            //Logger.InstallTelnetLogger(59999, 60, true);
+            //Logger.SetLogLevel(Level.Trace);
 
             var name = GetLocalPeerName();
             Debug.WriteLine($"Connecting to server from local peer: {name}");

--- a/Samples/DataChannelOrtc/DataChannelOrtc/Signaling/TcpSignaler.cs
+++ b/Samples/DataChannelOrtc/DataChannelOrtc/Signaling/TcpSignaler.cs
@@ -168,6 +168,7 @@ namespace DataChannelOrtc.Signaling
                 "\r\n" +
                 "{3}",
                 _myId, peerId, message.Length, message);
+            //Debug.WriteLine("--> SEND TO PEER\n" + buffer + "===>END");
             return await ControlSocketRequestAsync(buffer);
         }
 
@@ -263,6 +264,7 @@ namespace DataChannelOrtc.Signaling
         /// <returns>False if fails to parse the server response.</returns>
         private bool ParseServerResponse(string buffer, out int peer_id, out int eoh)
         {
+            //Debug.WriteLine("<--- Server reply:\n" + buffer + "<===END");
             peer_id = -1;
             eoh = -1;
             try


### PR DESCRIPTION
- Data was being sent to selected peer not active remote peer
- SCTP transport must be started before DTLS transport is connected otherwise remote party may create incoming SCTP transport before local transport is started (avoid this by using SCTP transport listener in the future as another approach)